### PR TITLE
Build Golang MCP server for Google Sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteTest
+*.out
+
+# Dependency directories
+vendor/
+
+# Go workspace file
+go.work
+
+# Credentials
+credentials.json
+token.json
+service-account.json
+*.json
+
+# Except example files
+!credentials.example.json
+
+# Build output
+mcp-google-sheets
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+.PHONY: build clean install test run
+
+BINARY_NAME=mcp-google-sheets
+GOBASE=$(shell pwd)
+GOBIN=$(GOBASE)/bin
+
+build:
+	@echo "Building $(BINARY_NAME)..."
+	@go build -o $(BINARY_NAME) .
+	@echo "Build complete!"
+
+clean:
+	@echo "Cleaning..."
+	@rm -f $(BINARY_NAME)
+	@rm -rf $(GOBIN)
+	@go clean
+	@echo "Clean complete!"
+
+install:
+	@echo "Installing dependencies..."
+	@go mod download
+	@go mod tidy
+	@echo "Dependencies installed!"
+
+test:
+	@echo "Running tests..."
+	@go test -v ./...
+	@echo "Tests complete!"
+
+run: build
+	@echo "Running $(BINARY_NAME)..."
+	@./$(BINARY_NAME)
+
+# Build for multiple platforms
+build-all: build-linux build-darwin build-windows
+
+build-linux:
+	@echo "Building for Linux..."
+	@GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME)-linux .
+	@echo "Linux build complete!"
+
+build-darwin:
+	@echo "Building for macOS..."
+	@GOOS=darwin GOARCH=amd64 go build -o $(BINARY_NAME)-mac .
+	@echo "macOS build complete!"
+
+build-windows:
+	@echo "Building for Windows..."
+	@GOOS=windows GOARCH=amd64 go build -o $(BINARY_NAME).exe .
+	@echo "Windows build complete!"
+
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build the binary"
+	@echo "  clean       - Remove built binaries and clean cache"
+	@echo "  install     - Install Go dependencies"
+	@echo "  test        - Run tests"
+	@echo "  run         - Build and run the server"
+	@echo "  build-all   - Build for all platforms (Linux, macOS, Windows)"
+	@echo "  help        - Show this help message"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,333 @@
-# mcp-google-sheets
-A local MCP server for natively accessing and editing Google Sheets via it's API
+# MCP Google Sheets Server
+
+A Model Context Protocol (MCP) server written in Go that provides native integration with Google Sheets API. This server enables Claude and other MCP clients to create, read, update, and manage Google Sheets without resorting to xlsx files or Python code.
+
+## Features
+
+- **Read Google Sheets**: Retrieve data from any sheet with flexible range selection
+- **Write & Update**: Write data to specific ranges or update existing content
+- **Append Data**: Add new rows to sheets without overwriting existing data
+- **Create Spreadsheets**: Create new Google Sheets programmatically
+- **Sheet Management**: Add new sheets (tabs), clear data, get spreadsheet metadata
+- **Batch Operations**: Perform multiple updates in a single request for efficiency
+- **Native Go Implementation**: Fast, lightweight, and efficient
+- **MCP Protocol**: Full compatibility with Claude Code and other MCP clients
+
+## Prerequisites
+
+- Go 1.21 or higher
+- Google Cloud Project with Sheets API enabled
+- Service Account credentials (JSON key file)
+
+## Quick Start
+
+### 1. Set Up Google Cloud Project
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Enable the Google Sheets API:
+   - Navigate to "APIs & Services" > "Library"
+   - Search for "Google Sheets API"
+   - Click "Enable"
+
+### 2. Create Service Account
+
+1. Go to "APIs & Services" > "Credentials"
+2. Click "Create Credentials" > "Service Account"
+3. Fill in the service account details and click "Create"
+4. Grant the service account appropriate roles (optional for private sheets)
+5. Click "Done"
+6. Click on the created service account
+7. Go to "Keys" tab
+8. Click "Add Key" > "Create New Key"
+9. Select "JSON" and click "Create"
+10. Save the downloaded JSON file as `credentials.json` in the project directory
+
+### 3. Share Sheets with Service Account
+
+For the service account to access your Google Sheets:
+1. Open the Google Sheet you want to access
+2. Click "Share"
+3. Add the service account email (found in `credentials.json` as `client_email`)
+4. Grant appropriate permissions (Viewer, Editor, etc.)
+
+### 4. Install and Build
+
+```bash
+# Clone the repository
+git clone https://github.com/conallob/mcp-google-sheets.git
+cd mcp-google-sheets
+
+# Download dependencies
+go mod download
+
+# Build the server
+go build -o mcp-google-sheets
+
+# Or run directly
+go run main.go
+```
+
+### 5. Configure Environment
+
+Set the environment variable to point to your credentials:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/credentials.json"
+```
+
+Or add to your shell profile (~/.bashrc, ~/.zshrc, etc.):
+
+```bash
+echo 'export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/credentials.json"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## MCP Client Configuration
+
+### Claude Code Configuration
+
+Add to your Claude Code MCP settings (typically in `~/.claude/mcp_settings.json` or through Claude Code settings):
+
+```json
+{
+  "mcpServers": {
+    "google-sheets": {
+      "command": "/path/to/mcp-google-sheets/mcp-google-sheets",
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/your/credentials.json"
+      }
+    }
+  }
+}
+```
+
+### Other MCP Clients
+
+For other MCP clients, configure the server with:
+- **Command**: Path to the `mcp-google-sheets` binary
+- **Environment**: Set `GOOGLE_APPLICATION_CREDENTIALS` to your credentials file path
+- **Protocol**: stdio (standard input/output)
+
+## Available Tools
+
+### read_sheet
+
+Read data from a Google Sheet.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID from the URL
+- `range` (optional): A1 notation range (e.g., "Sheet1!A1:D10"). Defaults to entire first sheet.
+
+**Example:**
+```json
+{
+  "spreadsheet_id": "1abc123def456",
+  "range": "Sheet1!A1:C10"
+}
+```
+
+### write_sheet
+
+Write data to a Google Sheet, overwriting existing content.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID
+- `range` (required): A1 notation range to write to
+- `values` (required): 2D array of values (rows and columns)
+
+**Example:**
+```json
+{
+  "spreadsheet_id": "1abc123def456",
+  "range": "Sheet1!A1:C2",
+  "values": [
+    ["Name", "Age", "City"],
+    ["Alice", "30", "NYC"]
+  ]
+}
+```
+
+### append_sheet
+
+Append data to a sheet after the last row with data.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID
+- `range` (required): Range indicating which columns to append to
+- `values` (required): 2D array of values to append
+
+**Example:**
+```json
+{
+  "spreadsheet_id": "1abc123def456",
+  "range": "Sheet1!A:C",
+  "values": [
+    ["Bob", "25", "SF"],
+    ["Charlie", "35", "LA"]
+  ]
+}
+```
+
+### create_spreadsheet
+
+Create a new Google Spreadsheet.
+
+**Parameters:**
+- `title` (required): Title for the new spreadsheet
+- `sheets` (optional): Array of sheet names to create
+
+**Example:**
+```json
+{
+  "title": "My New Spreadsheet",
+  "sheets": ["Data", "Analysis", "Summary"]
+}
+```
+
+**Returns:** Spreadsheet ID and URL
+
+### get_spreadsheet_info
+
+Get metadata about a spreadsheet.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID
+
+**Returns:** Information about sheets, dimensions, properties, etc.
+
+### add_sheet
+
+Add a new sheet (tab) to an existing spreadsheet.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID
+- `sheet_name` (required): Name for the new sheet
+
+### clear_sheet
+
+Clear all data in a specified range.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID
+- `range` (required): A1 notation range to clear
+
+### batch_update
+
+Perform multiple operations in a single request. Supports complex operations like formatting, conditional formatting, adding/deleting rows, etc.
+
+**Parameters:**
+- `spreadsheet_id` (required): The spreadsheet ID
+- `requests` (required): Array of request objects (see [Google Sheets API documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request))
+
+## Usage Examples
+
+### With Claude Code
+
+Once configured, you can ask Claude to interact with your sheets:
+
+```
+"Read the data from my spreadsheet 1abc123def456 in range Sheet1!A1:E100"
+
+"Create a new spreadsheet called 'Sales Report 2024' with sheets: Q1, Q2, Q3, Q4"
+
+"Append the following data to my sheet 1abc123def456 in the range Sheet1!A:D:
+Name,Product,Quantity,Price
+John,Widget,5,29.99
+Jane,Gadget,3,49.99"
+
+"Clear the range Sheet1!A1:Z1000 in spreadsheet 1abc123def456"
+```
+
+### Programmatic Usage
+
+You can also integrate this server into your own MCP client applications. The server communicates via JSON-RPC 2.0 over stdio.
+
+## Finding Spreadsheet IDs
+
+The spreadsheet ID is in the URL of your Google Sheet:
+```
+https://docs.google.com/spreadsheets/d/1abc123def456ghi789/edit
+                                      ^^^^^^^^^^^^^^^^
+                                      This is the ID
+```
+
+## Troubleshooting
+
+### Authentication Errors
+
+- Ensure `GOOGLE_APPLICATION_CREDENTIALS` points to a valid JSON key file
+- Verify the service account email has access to the spreadsheet
+- Check that the Google Sheets API is enabled in your Google Cloud project
+
+### Permission Errors
+
+- Make sure you've shared the spreadsheet with the service account email
+- Grant appropriate permissions (Editor for write operations, Viewer for read-only)
+
+### Connection Errors
+
+- Verify your internet connection
+- Check if Google APIs are accessible from your network
+- Ensure firewall/proxy settings allow access to googleapis.com
+
+## Development
+
+### Project Structure
+
+```
+mcp-google-sheets/
+├── main.go                      # MCP server implementation
+├── sheets/
+│   └── client.go               # Google Sheets API client
+├── go.mod                      # Go module definition
+├── credentials.example.json    # Example credentials file
+└── README.md                   # This file
+```
+
+### Building from Source
+
+```bash
+# Install dependencies
+go mod download
+
+# Run tests (if available)
+go test ./...
+
+# Build
+go build -o mcp-google-sheets
+
+# Build for different platforms
+GOOS=linux GOARCH=amd64 go build -o mcp-google-sheets-linux
+GOOS=darwin GOARCH=amd64 go build -o mcp-google-sheets-mac
+GOOS=windows GOARCH=amd64 go build -o mcp-google-sheets.exe
+```
+
+## Security Considerations
+
+- **Never commit `credentials.json`** to version control
+- Store credentials securely and restrict file permissions:
+  ```bash
+  chmod 600 credentials.json
+  ```
+- Use service accounts with minimal necessary permissions
+- Regularly rotate service account keys
+- Consider using Google Cloud Secret Manager for production deployments
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+See [LICENSE](LICENSE) file for details.
+
+## Resources
+
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+- [Google Sheets API Documentation](https://developers.google.com/sheets/api)
+- [Google Cloud Authentication](https://cloud.google.com/docs/authentication)
+
+## Support
+
+For issues, questions, or contributions, please use the GitHub issue tracker.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,344 @@
+# MCP Google Sheets Server - Detailed Setup Guide
+
+This guide provides step-by-step instructions for setting up the MCP Google Sheets Server.
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Google Cloud Setup](#google-cloud-setup)
+3. [Service Account Configuration](#service-account-configuration)
+4. [Local Installation](#local-installation)
+5. [MCP Client Configuration](#mcp-client-configuration)
+6. [Testing the Connection](#testing-the-connection)
+7. [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+### Required Software
+
+- **Go**: Version 1.21 or higher
+  - Download from: https://golang.org/doc/install
+  - Verify installation: `go version`
+
+- **Git**: For cloning the repository
+  - Download from: https://git-scm.com/downloads
+
+- **Google Account**: To access Google Cloud Console
+
+## Google Cloud Setup
+
+### Step 1: Create a Google Cloud Project
+
+1. Navigate to [Google Cloud Console](https://console.cloud.google.com/)
+2. Click the project dropdown at the top of the page
+3. Click "New Project"
+4. Enter a project name (e.g., "MCP Google Sheets")
+5. Select a billing account (if required)
+6. Click "Create"
+7. Wait for the project to be created and select it
+
+### Step 2: Enable Google Sheets API
+
+1. In your Google Cloud project, go to the navigation menu (☰)
+2. Navigate to "APIs & Services" → "Library"
+3. In the search bar, type "Google Sheets API"
+4. Click on "Google Sheets API" in the results
+5. Click the "Enable" button
+6. Wait for the API to be enabled
+
+## Service Account Configuration
+
+### Step 3: Create a Service Account
+
+1. Navigate to "APIs & Services" → "Credentials"
+2. Click "Create Credentials" at the top
+3. Select "Service Account"
+4. Fill in the service account details:
+   - **Service account name**: `mcp-sheets-service`
+   - **Service account ID**: (auto-generated)
+   - **Description**: "Service account for MCP Google Sheets server"
+5. Click "Create and Continue"
+6. (Optional) Grant roles if needed:
+   - For accessing organization-wide sheets, you might need specific roles
+   - For personal sheets, you can skip this step
+7. Click "Continue" and then "Done"
+
+### Step 4: Create and Download Service Account Key
+
+1. On the "Credentials" page, find your newly created service account
+2. Click on the service account email
+3. Go to the "Keys" tab
+4. Click "Add Key" → "Create new key"
+5. Select "JSON" as the key type
+6. Click "Create"
+7. The JSON key file will be automatically downloaded
+8. **Important**: Save this file securely - you cannot download it again
+
+### Step 5: Note the Service Account Email
+
+In the downloaded JSON file, find the `client_email` field. It will look like:
+```
+mcp-sheets-service@your-project-id.iam.gserviceaccount.com
+```
+
+You'll need this email to share Google Sheets with the service account.
+
+## Local Installation
+
+### Step 6: Clone and Build the Server
+
+```bash
+# Clone the repository
+git clone https://github.com/conallob/mcp-google-sheets.git
+cd mcp-google-sheets
+
+# Run the automated setup script
+./setup.sh
+```
+
+Or manually:
+
+```bash
+# Install dependencies
+go mod download
+go mod tidy
+
+# Build the server
+go build -o mcp-google-sheets
+
+# Or use the Makefile
+make install
+make build
+```
+
+### Step 7: Configure Credentials
+
+1. Rename your downloaded service account key to `credentials.json`
+2. Move it to the project directory:
+   ```bash
+   mv ~/Downloads/your-project-xyz123.json ./credentials.json
+   ```
+3. Secure the file permissions:
+   ```bash
+   chmod 600 credentials.json
+   ```
+
+### Step 8: Set Environment Variable
+
+```bash
+# Option 1: Export for current session
+export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/credentials.json"
+
+# Option 2: Add to your shell profile for persistence
+echo 'export GOOGLE_APPLICATION_CREDENTIALS="/absolute/path/to/mcp-google-sheets/credentials.json"' >> ~/.bashrc
+source ~/.bashrc
+
+# Option 3: Use the generated .env file
+source .env
+```
+
+## MCP Client Configuration
+
+### For Claude Code
+
+#### Method 1: Using Claude Code Settings UI
+
+1. Open Claude Code
+2. Go to Settings → MCP Servers
+3. Add a new server with:
+   - **Name**: `google-sheets`
+   - **Command**: `/absolute/path/to/mcp-google-sheets/mcp-google-sheets`
+   - **Environment Variables**:
+     - `GOOGLE_APPLICATION_CREDENTIALS`: `/absolute/path/to/credentials.json`
+
+#### Method 2: Manual Configuration File
+
+Edit or create `~/.claude/mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "google-sheets": {
+      "command": "/absolute/path/to/mcp-google-sheets/mcp-google-sheets",
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/absolute/path/to/credentials.json"
+      }
+    }
+  }
+}
+```
+
+**Replace** `/absolute/path/to/` with your actual paths.
+
+### For Other MCP Clients
+
+Configure the MCP client to:
+- **Protocol**: stdio (standard input/output)
+- **Command**: Path to the `mcp-google-sheets` binary
+- **Environment**:
+  - `GOOGLE_APPLICATION_CREDENTIALS` = path to `credentials.json`
+
+## Testing the Connection
+
+### Step 9: Share a Test Spreadsheet
+
+1. Create or open a Google Sheet
+2. Click the "Share" button
+3. In the "Add people and groups" field, paste your service account email:
+   ```
+   mcp-sheets-service@your-project-id.iam.gserviceaccount.com
+   ```
+4. Set appropriate permissions (Editor recommended for testing)
+5. Uncheck "Notify people" (the service account won't read emails)
+6. Click "Share"
+
+### Step 10: Test with Claude Code
+
+1. Open Claude Code
+2. Start a conversation and try commands like:
+
+```
+"Read data from my spreadsheet 1abc123def456"
+
+"Create a new spreadsheet called 'Test Sheet'"
+
+"Get information about spreadsheet 1abc123def456"
+```
+
+Replace `1abc123def456` with your actual spreadsheet ID (from the URL).
+
+### Step 11: Manual Testing (Optional)
+
+You can test the server directly:
+
+```bash
+# Start the server
+./mcp-google-sheets
+
+# In another terminal, send a test request
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | ./mcp-google-sheets
+```
+
+## Troubleshooting
+
+### Error: "GOOGLE_APPLICATION_CREDENTIALS environment variable not set"
+
+**Solution**: Ensure the environment variable is set:
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+```
+
+### Error: "Unable to create sheets service"
+
+**Possible causes**:
+1. Invalid credentials.json file
+2. Incorrect file path
+3. Missing Google Sheets API enablement
+
+**Solution**:
+- Verify the credentials file exists and is valid JSON
+- Check the file path is absolute
+- Re-enable the Google Sheets API in Google Cloud Console
+
+### Error: "Permission denied" or "403 Forbidden"
+
+**Solution**: Share the spreadsheet with your service account email
+
+### Error: "Spreadsheet not found" or "404"
+
+**Possible causes**:
+1. Incorrect spreadsheet ID
+2. Spreadsheet not shared with service account
+3. Spreadsheet deleted
+
+**Solution**:
+- Verify the spreadsheet ID from the URL
+- Check sharing settings
+- Ensure spreadsheet exists
+
+### Build Errors
+
+If you encounter build errors:
+
+```bash
+# Clear the Go cache
+go clean -modcache
+
+# Re-download dependencies
+go mod download
+
+# Rebuild
+go build -o mcp-google-sheets
+```
+
+### Connection Issues
+
+If the MCP client can't connect to the server:
+
+1. Verify the binary path is correct
+2. Check the binary has execute permissions: `chmod +x mcp-google-sheets`
+3. Test the server runs standalone
+4. Check MCP client logs for detailed errors
+
+## Advanced Configuration
+
+### Using Multiple Service Accounts
+
+You can create multiple instances of the server with different credentials:
+
+```json
+{
+  "mcpServers": {
+    "google-sheets-personal": {
+      "command": "/path/to/mcp-google-sheets",
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/personal-credentials.json"
+      }
+    },
+    "google-sheets-work": {
+      "command": "/path/to/mcp-google-sheets",
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/work-credentials.json"
+      }
+    }
+  }
+}
+```
+
+### Production Deployment
+
+For production use:
+
+1. **Use Google Cloud Secret Manager** instead of local credential files
+2. **Implement credential rotation** policies
+3. **Use service accounts with minimal necessary permissions**
+4. **Monitor API usage** in Google Cloud Console
+5. **Set up logging and alerting**
+
+## Security Best Practices
+
+1. **Never commit credentials.json to version control**
+   - Already in .gitignore, but verify
+2. **Restrict file permissions**: `chmod 600 credentials.json`
+3. **Regularly rotate service account keys** (every 90 days recommended)
+4. **Use separate service accounts** for different environments (dev, staging, prod)
+5. **Monitor service account activity** in Google Cloud Console
+6. **Revoke unused service account keys**
+
+## Getting Help
+
+- **Documentation**: See [README.md](README.md)
+- **Google Sheets API**: https://developers.google.com/sheets/api
+- **MCP Protocol**: https://modelcontextprotocol.io/
+- **Issues**: https://github.com/conallob/mcp-google-sheets/issues
+
+## Next Steps
+
+Once setup is complete:
+
+1. Read the [README.md](README.md) for usage examples
+2. Explore the available tools and their parameters
+3. Try creating, reading, and updating spreadsheets
+4. Integrate with your workflows using Claude Code or other MCP clients
+
+Happy spreadsheeting!

--- a/credentials.example.json
+++ b/credentials.example.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  "private_key_id": "your-private-key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nYOUR-PRIVATE-KEY-HERE\n-----END PRIVATE KEY-----\n",
+  "client_email": "your-service-account@your-project-id.iam.gserviceaccount.com",
+  "client_id": "your-client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/your-service-account%40your-project-id.iam.gserviceaccount.com"
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/conallob/mcp-google-sheets
+
+go 1.21
+
+require (
+	google.golang.org/api v0.154.0
+)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/conallob/mcp-google-sheets/sheets"
+	"google.golang.org/api/option"
+	sheetsapi "google.golang.org/api/sheets/v4"
+)
+
+const (
+	serverName    = "mcp-google-sheets"
+	serverVersion = "1.0.0"
+)
+
+type MCPRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type MCPResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *MCPError   `json:"error,omitempty"`
+}
+
+type MCPError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type MCPServer struct {
+	sheetsClient *sheets.Client
+	ctx          context.Context
+}
+
+func NewMCPServer(ctx context.Context) (*MCPServer, error) {
+	credPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if credPath == "" {
+		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS environment variable not set")
+	}
+
+	srv, err := sheetsapi.NewService(ctx, option.WithCredentialsFile(credPath))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create sheets service: %v", err)
+	}
+
+	return &MCPServer{
+		sheetsClient: sheets.NewClient(srv),
+		ctx:          ctx,
+	}, nil
+}
+
+func (s *MCPServer) handleRequest(req MCPRequest) MCPResponse {
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "tools/list":
+		return s.handleToolsList(req)
+	case "tools/call":
+		return s.handleToolsCall(req)
+	case "ping":
+		return MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  map[string]interface{}{},
+		}
+	default:
+		return MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &MCPError{
+				Code:    -32601,
+				Message: fmt.Sprintf("Method not found: %s", req.Method),
+			},
+		}
+	}
+}
+
+func (s *MCPServer) handleInitialize(req MCPRequest) MCPResponse {
+	return MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"serverInfo": map[string]string{
+				"name":    serverName,
+				"version": serverVersion,
+			},
+			"capabilities": map[string]interface{}{
+				"tools": map[string]bool{},
+			},
+		},
+	}
+}
+
+func (s *MCPServer) handleToolsList(req MCPRequest) MCPResponse {
+	tools := []map[string]interface{}{
+		{
+			"name":        "read_sheet",
+			"description": "Read data from a Google Sheet. Specify the spreadsheet ID and optional range (e.g., 'Sheet1!A1:D10'). If no range is provided, reads the entire first sheet.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet (from the URL)",
+					},
+					"range": map[string]interface{}{
+						"type":        "string",
+						"description": "The A1 notation range to read (e.g., 'Sheet1!A1:D10'). Optional - defaults to entire first sheet.",
+					},
+				},
+				"required": []string{"spreadsheet_id"},
+			},
+		},
+		{
+			"name":        "write_sheet",
+			"description": "Write data to a Google Sheet. Specify the spreadsheet ID, range, and data as a 2D array. Data overwrites existing content in the range.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet (from the URL)",
+					},
+					"range": map[string]interface{}{
+						"type":        "string",
+						"description": "The A1 notation range to write to (e.g., 'Sheet1!A1:D10')",
+					},
+					"values": map[string]interface{}{
+						"type":        "array",
+						"description": "2D array of values to write (array of rows, each row is an array of cell values)",
+						"items": map[string]interface{}{
+							"type": "array",
+							"items": map[string]interface{}{
+								"type": "string",
+							},
+						},
+					},
+				},
+				"required": []string{"spreadsheet_id", "range", "values"},
+			},
+		},
+		{
+			"name":        "append_sheet",
+			"description": "Append data to a Google Sheet. Adds new rows after the last row with data in the specified range.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet (from the URL)",
+					},
+					"range": map[string]interface{}{
+						"type":        "string",
+						"description": "The A1 notation range (e.g., 'Sheet1!A:D' or 'Sheet1')",
+					},
+					"values": map[string]interface{}{
+						"type":        "array",
+						"description": "2D array of values to append (array of rows)",
+						"items": map[string]interface{}{
+							"type": "array",
+							"items": map[string]interface{}{
+								"type": "string",
+							},
+						},
+					},
+				},
+				"required": []string{"spreadsheet_id", "range", "values"},
+			},
+		},
+		{
+			"name":        "create_spreadsheet",
+			"description": "Create a new Google Spreadsheet with the specified title and optional sheet names.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"title": map[string]interface{}{
+						"type":        "string",
+						"description": "The title of the new spreadsheet",
+					},
+					"sheets": map[string]interface{}{
+						"type":        "array",
+						"description": "Optional array of sheet names to create. If not provided, creates one default sheet.",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+					},
+				},
+				"required": []string{"title"},
+			},
+		},
+		{
+			"name":        "get_spreadsheet_info",
+			"description": "Get metadata about a spreadsheet including title, sheets, and properties.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet (from the URL)",
+					},
+				},
+				"required": []string{"spreadsheet_id"},
+			},
+		},
+		{
+			"name":        "add_sheet",
+			"description": "Add a new sheet (tab) to an existing spreadsheet.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet",
+					},
+					"sheet_name": map[string]interface{}{
+						"type":        "string",
+						"description": "The name for the new sheet",
+					},
+				},
+				"required": []string{"spreadsheet_id", "sheet_name"},
+			},
+		},
+		{
+			"name":        "clear_sheet",
+			"description": "Clear all data in a specified range of a Google Sheet.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet",
+					},
+					"range": map[string]interface{}{
+						"type":        "string",
+						"description": "The A1 notation range to clear (e.g., 'Sheet1!A1:D10' or 'Sheet1')",
+					},
+				},
+				"required": []string{"spreadsheet_id", "range"},
+			},
+		},
+		{
+			"name":        "batch_update",
+			"description": "Perform multiple update operations on a spreadsheet in a single request. Supports formatting, adding sheets, and more complex operations.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"spreadsheet_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the Google Spreadsheet",
+					},
+					"requests": map[string]interface{}{
+						"type":        "array",
+						"description": "Array of update request objects (see Google Sheets API documentation for request format)",
+					},
+				},
+				"required": []string{"spreadsheet_id", "requests"},
+			},
+		},
+	}
+
+	return MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]interface{}{
+			"tools": tools,
+		},
+	}
+}
+
+func (s *MCPServer) handleToolsCall(req MCPRequest) MCPResponse {
+	var params struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &MCPError{
+				Code:    -32602,
+				Message: "Invalid params",
+				Data:    err.Error(),
+			},
+		}
+	}
+
+	var result interface{}
+	var err error
+
+	switch params.Name {
+	case "read_sheet":
+		result, err = s.handleReadSheet(params.Arguments)
+	case "write_sheet":
+		result, err = s.handleWriteSheet(params.Arguments)
+	case "append_sheet":
+		result, err = s.handleAppendSheet(params.Arguments)
+	case "create_spreadsheet":
+		result, err = s.handleCreateSpreadsheet(params.Arguments)
+	case "get_spreadsheet_info":
+		result, err = s.handleGetSpreadsheetInfo(params.Arguments)
+	case "add_sheet":
+		result, err = s.handleAddSheet(params.Arguments)
+	case "clear_sheet":
+		result, err = s.handleClearSheet(params.Arguments)
+	case "batch_update":
+		result, err = s.handleBatchUpdate(params.Arguments)
+	default:
+		return MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &MCPError{
+				Code:    -32601,
+				Message: fmt.Sprintf("Tool not found: %s", params.Name),
+			},
+		}
+	}
+
+	if err != nil {
+		return MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error: &MCPError{
+				Code:    -32000,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	return MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]interface{}{
+			"content": []map[string]interface{}{
+				{
+					"type": "text",
+					"text": fmt.Sprintf("%v", result),
+				},
+			},
+		},
+	}
+}
+
+func (s *MCPServer) handleReadSheet(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string `json:"spreadsheet_id"`
+		Range         string `json:"range,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.ReadSheet(s.ctx, params.SpreadsheetID, params.Range)
+}
+
+func (s *MCPServer) handleWriteSheet(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string     `json:"spreadsheet_id"`
+		Range         string     `json:"range"`
+		Values        [][]string `json:"values"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.WriteSheet(s.ctx, params.SpreadsheetID, params.Range, params.Values)
+}
+
+func (s *MCPServer) handleAppendSheet(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string     `json:"spreadsheet_id"`
+		Range         string     `json:"range"`
+		Values        [][]string `json:"values"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.AppendSheet(s.ctx, params.SpreadsheetID, params.Range, params.Values)
+}
+
+func (s *MCPServer) handleCreateSpreadsheet(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		Title  string   `json:"title"`
+		Sheets []string `json:"sheets,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.CreateSpreadsheet(s.ctx, params.Title, params.Sheets)
+}
+
+func (s *MCPServer) handleGetSpreadsheetInfo(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string `json:"spreadsheet_id"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.GetSpreadsheetInfo(s.ctx, params.SpreadsheetID)
+}
+
+func (s *MCPServer) handleAddSheet(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string `json:"spreadsheet_id"`
+		SheetName     string `json:"sheet_name"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.AddSheet(s.ctx, params.SpreadsheetID, params.SheetName)
+}
+
+func (s *MCPServer) handleClearSheet(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string `json:"spreadsheet_id"`
+		Range         string `json:"range"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.ClearSheet(s.ctx, params.SpreadsheetID, params.Range)
+}
+
+func (s *MCPServer) handleBatchUpdate(args json.RawMessage) (interface{}, error) {
+	var params struct {
+		SpreadsheetID string                   `json:"spreadsheet_id"`
+		Requests      []map[string]interface{} `json:"requests"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return nil, err
+	}
+	return s.sheetsClient.BatchUpdate(s.ctx, params.SpreadsheetID, params.Requests)
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	ctx := context.Background()
+	server, err := NewMCPServer(ctx)
+	if err != nil {
+		log.Fatalf("Failed to create MCP server: %v", err)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var req MCPRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			log.Printf("Error parsing request: %v", err)
+			continue
+		}
+
+		resp := server.handleRequest(req)
+		if err := encoder.Encode(resp); err != nil {
+			log.Printf("Error encoding response: %v", err)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading from stdin: %v", err)
+	}
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Setup script for MCP Google Sheets Server
+
+set -e
+
+echo "==================================="
+echo "MCP Google Sheets Server Setup"
+echo "==================================="
+echo ""
+
+# Check if Go is installed
+if ! command -v go &> /dev/null; then
+    echo "Error: Go is not installed. Please install Go 1.21 or higher."
+    echo "Visit: https://golang.org/doc/install"
+    exit 1
+fi
+
+GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+echo "Found Go version: $GO_VERSION"
+echo ""
+
+# Install dependencies
+echo "Installing Go dependencies..."
+go mod download
+go mod tidy
+echo "Dependencies installed successfully!"
+echo ""
+
+# Check for credentials file
+if [ ! -f "credentials.json" ]; then
+    echo "Warning: credentials.json not found!"
+    echo ""
+    echo "To set up Google Sheets API access:"
+    echo "1. Go to https://console.cloud.google.com/"
+    echo "2. Create a new project or select existing one"
+    echo "3. Enable Google Sheets API"
+    echo "4. Create a Service Account and download the JSON key"
+    echo "5. Save the key as 'credentials.json' in this directory"
+    echo ""
+    echo "See credentials.example.json for the expected format."
+    echo ""
+else
+    echo "Found credentials.json"
+    echo ""
+fi
+
+# Build the server
+echo "Building the MCP server..."
+go build -o mcp-google-sheets .
+echo "Build complete! Binary created: mcp-google-sheets"
+echo ""
+
+# Set up environment variable
+echo "Setting up environment..."
+CREDS_PATH="$(pwd)/credentials.json"
+echo "export GOOGLE_APPLICATION_CREDENTIALS=\"$CREDS_PATH\"" > .env
+
+echo "Environment configuration saved to .env"
+echo ""
+echo "To use the environment variables, run:"
+echo "  source .env"
+echo ""
+
+echo "==================================="
+echo "Setup Complete!"
+echo "==================================="
+echo ""
+echo "Next steps:"
+echo "1. Ensure you have credentials.json in this directory"
+echo "2. Run: source .env"
+echo "3. Test the server: ./mcp-google-sheets"
+echo ""
+echo "For Claude Code integration, add this to your MCP settings:"
+echo ""
+echo '{
+  "mcpServers": {
+    "google-sheets": {
+      "command": "'$(pwd)'/mcp-google-sheets",
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "'$CREDS_PATH'"
+      }
+    }
+  }
+}'
+echo ""

--- a/sheets/client.go
+++ b/sheets/client.go
@@ -1,0 +1,276 @@
+package sheets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/api/sheets/v4"
+)
+
+// Client wraps the Google Sheets API service
+type Client struct {
+	service *sheets.Service
+}
+
+// NewClient creates a new Sheets client
+func NewClient(service *sheets.Service) *Client {
+	return &Client{
+		service: service,
+	}
+}
+
+// ReadSheet reads data from a spreadsheet range
+func (c *Client) ReadSheet(ctx context.Context, spreadsheetID, readRange string) (interface{}, error) {
+	if readRange == "" {
+		readRange = "Sheet1"
+	}
+
+	resp, err := c.service.Spreadsheets.Values.Get(spreadsheetID, readRange).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve data from sheet: %v", err)
+	}
+
+	if len(resp.Values) == 0 {
+		return map[string]interface{}{
+			"range":  resp.Range,
+			"values": [][]string{},
+			"message": "No data found",
+		}, nil
+	}
+
+	// Convert interface{} values to strings for easier handling
+	stringValues := make([][]string, len(resp.Values))
+	for i, row := range resp.Values {
+		stringRow := make([]string, len(row))
+		for j, cell := range row {
+			stringRow[j] = fmt.Sprintf("%v", cell)
+		}
+		stringValues[i] = stringRow
+	}
+
+	return map[string]interface{}{
+		"range":      resp.Range,
+		"values":     stringValues,
+		"row_count":  len(stringValues),
+		"col_count":  len(stringValues[0]),
+	}, nil
+}
+
+// WriteSheet writes data to a spreadsheet range
+func (c *Client) WriteSheet(ctx context.Context, spreadsheetID, writeRange string, values [][]string) (interface{}, error) {
+	// Convert [][]string to [][]interface{} for the API
+	interfaceValues := make([][]interface{}, len(values))
+	for i, row := range values {
+		interfaceRow := make([]interface{}, len(row))
+		for j, cell := range row {
+			interfaceRow[j] = cell
+		}
+		interfaceValues[i] = interfaceRow
+	}
+
+	valueRange := &sheets.ValueRange{
+		Values: interfaceValues,
+	}
+
+	resp, err := c.service.Spreadsheets.Values.Update(
+		spreadsheetID,
+		writeRange,
+		valueRange,
+	).ValueInputOption("USER_ENTERED").Context(ctx).Do()
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to write data to sheet: %v", err)
+	}
+
+	return map[string]interface{}{
+		"updated_range":   resp.UpdatedRange,
+		"updated_rows":    resp.UpdatedRows,
+		"updated_columns": resp.UpdatedColumns,
+		"updated_cells":   resp.UpdatedCells,
+		"message":         "Data written successfully",
+	}, nil
+}
+
+// AppendSheet appends data to a spreadsheet
+func (c *Client) AppendSheet(ctx context.Context, spreadsheetID, appendRange string, values [][]string) (interface{}, error) {
+	// Convert [][]string to [][]interface{} for the API
+	interfaceValues := make([][]interface{}, len(values))
+	for i, row := range values {
+		interfaceRow := make([]interface{}, len(row))
+		for j, cell := range row {
+			interfaceRow[j] = cell
+		}
+		interfaceValues[i] = interfaceRow
+	}
+
+	valueRange := &sheets.ValueRange{
+		Values: interfaceValues,
+	}
+
+	resp, err := c.service.Spreadsheets.Values.Append(
+		spreadsheetID,
+		appendRange,
+		valueRange,
+	).ValueInputOption("USER_ENTERED").InsertDataOption("INSERT_ROWS").Context(ctx).Do()
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to append data to sheet: %v", err)
+	}
+
+	updates := resp.Updates
+	return map[string]interface{}{
+		"updated_range":   updates.UpdatedRange,
+		"updated_rows":    updates.UpdatedRows,
+		"updated_columns": updates.UpdatedColumns,
+		"updated_cells":   updates.UpdatedCells,
+		"message":         "Data appended successfully",
+	}, nil
+}
+
+// CreateSpreadsheet creates a new spreadsheet
+func (c *Client) CreateSpreadsheet(ctx context.Context, title string, sheetNames []string) (interface{}, error) {
+	spreadsheet := &sheets.Spreadsheet{
+		Properties: &sheets.SpreadsheetProperties{
+			Title: title,
+		},
+	}
+
+	// Add sheets if specified
+	if len(sheetNames) > 0 {
+		spreadsheet.Sheets = make([]*sheets.Sheet, len(sheetNames))
+		for i, name := range sheetNames {
+			spreadsheet.Sheets[i] = &sheets.Sheet{
+				Properties: &sheets.SheetProperties{
+					Title: name,
+				},
+			}
+		}
+	}
+
+	resp, err := c.service.Spreadsheets.Create(spreadsheet).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create spreadsheet: %v", err)
+	}
+
+	sheetTitles := make([]string, len(resp.Sheets))
+	for i, sheet := range resp.Sheets {
+		sheetTitles[i] = sheet.Properties.Title
+	}
+
+	return map[string]interface{}{
+		"spreadsheet_id":  resp.SpreadsheetId,
+		"spreadsheet_url": resp.SpreadsheetUrl,
+		"title":           resp.Properties.Title,
+		"sheets":          sheetTitles,
+		"message":         "Spreadsheet created successfully",
+	}, nil
+}
+
+// GetSpreadsheetInfo retrieves metadata about a spreadsheet
+func (c *Client) GetSpreadsheetInfo(ctx context.Context, spreadsheetID string) (interface{}, error) {
+	resp, err := c.service.Spreadsheets.Get(spreadsheetID).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve spreadsheet info: %v", err)
+	}
+
+	sheetInfo := make([]map[string]interface{}, len(resp.Sheets))
+	for i, sheet := range resp.Sheets {
+		props := sheet.Properties
+		sheetInfo[i] = map[string]interface{}{
+			"sheet_id":    props.SheetId,
+			"title":       props.Title,
+			"index":       props.Index,
+			"sheet_type":  props.SheetType,
+			"row_count":   props.GridProperties.RowCount,
+			"col_count":   props.GridProperties.ColumnCount,
+			"frozen_rows": props.GridProperties.FrozenRowCount,
+			"frozen_cols": props.GridProperties.FrozenColumnCount,
+		}
+	}
+
+	return map[string]interface{}{
+		"spreadsheet_id":  resp.SpreadsheetId,
+		"title":           resp.Properties.Title,
+		"locale":          resp.Properties.Locale,
+		"time_zone":       resp.Properties.TimeZone,
+		"spreadsheet_url": resp.SpreadsheetUrl,
+		"sheets":          sheetInfo,
+	}, nil
+}
+
+// AddSheet adds a new sheet to an existing spreadsheet
+func (c *Client) AddSheet(ctx context.Context, spreadsheetID, sheetName string) (interface{}, error) {
+	requests := []*sheets.Request{
+		{
+			AddSheet: &sheets.AddSheetRequest{
+				Properties: &sheets.SheetProperties{
+					Title: sheetName,
+				},
+			},
+		},
+	}
+
+	batchUpdateRequest := &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: requests,
+	}
+
+	resp, err := c.service.Spreadsheets.BatchUpdate(spreadsheetID, batchUpdateRequest).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to add sheet: %v", err)
+	}
+
+	if len(resp.Replies) > 0 && resp.Replies[0].AddSheet != nil {
+		props := resp.Replies[0].AddSheet.Properties
+		return map[string]interface{}{
+			"sheet_id": props.SheetId,
+			"title":    props.Title,
+			"index":    props.Index,
+			"message":  "Sheet added successfully",
+		}, nil
+	}
+
+	return map[string]interface{}{
+		"message": "Sheet added successfully",
+	}, nil
+}
+
+// ClearSheet clears data in a specified range
+func (c *Client) ClearSheet(ctx context.Context, spreadsheetID, clearRange string) (interface{}, error) {
+	clearRequest := &sheets.ClearValuesRequest{}
+
+	resp, err := c.service.Spreadsheets.Values.Clear(spreadsheetID, clearRange, clearRequest).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to clear sheet: %v", err)
+	}
+
+	return map[string]interface{}{
+		"cleared_range": resp.ClearedRange,
+		"message":       "Range cleared successfully",
+	}, nil
+}
+
+// BatchUpdate performs multiple updates on a spreadsheet
+func (c *Client) BatchUpdate(ctx context.Context, spreadsheetID string, requestsData []map[string]interface{}) (interface{}, error) {
+	// Convert the generic map to JSON and back to sheets.Request
+	requestsJSON, err := json.Marshal(map[string]interface{}{"requests": requestsData})
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal requests: %v", err)
+	}
+
+	var batchUpdateRequest sheets.BatchUpdateSpreadsheetRequest
+	if err := json.Unmarshal(requestsJSON, &batchUpdateRequest); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal requests: %v", err)
+	}
+
+	resp, err := c.service.Spreadsheets.BatchUpdate(spreadsheetID, &batchUpdateRequest).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to batch update: %v", err)
+	}
+
+	return map[string]interface{}{
+		"spreadsheet_id": resp.SpreadsheetId,
+		"replies_count":  len(resp.Replies),
+		"message":        "Batch update completed successfully",
+	}, nil
+}


### PR DESCRIPTION
This commit implements a complete MCP (Model Context Protocol) server in Go that provides native integration with Google Sheets API.

Features:
- Read data from Google Sheets with flexible range selection
- Write and update sheet data with overwrite or append operations
- Create new spreadsheets with custom sheet names
- Manage sheets: add new tabs, clear ranges, get metadata
- Batch update operations for complex modifications
- Service account authentication via Google Cloud
- Full MCP protocol compliance for Claude Code integration

Implementation:
- main.go: MCP server with JSON-RPC 2.0 over stdio
- sheets/client.go: Google Sheets API client wrapper
- Comprehensive documentation in README.md and SETUP.md
- Build automation with Makefile and setup.sh script
- Example credentials template and .gitignore

Tools provided:
- read_sheet: Read data from spreadsheets
- write_sheet: Write data to specific ranges
- append_sheet: Append rows to sheets
- create_spreadsheet: Create new spreadsheets
- get_spreadsheet_info: Get metadata
- add_sheet: Add new sheet tabs
- clear_sheet: Clear ranges
- batch_update: Complex batch operations

🤖 Generated with [Claude Code](https://claude.com/claude-code), using the prompt:

```
Generate a local MCP server, written in golang, for connecting to Google Sheets via it's API, to natively create and edit Google Sheets without resorting to xlsx files or python code
```