### PR TITLE
Fix GoReleaser workflow configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,7 +100,7 @@ brews:
       email: bot@goreleaser.com
 
     # Folder inside the repository to put the formula
-    folder: Formula
+    directory: Formula
 
     # Caveats for the user after installation
     caveats: |


### PR DESCRIPTION
The 'folder' field has been renamed to 'directory' in GoReleaser v2. This fixes the unmarshal error: 'field folder not found in type config.Homebrew'

🤖 Generated with [Claude Code](https://claude.com/claude-code)